### PR TITLE
Forcing manual creation of user documentation

### DIFF
--- a/Dockerfile.base-image
+++ b/Dockerfile.base-image
@@ -5,3 +5,5 @@ RUN apt-get install software-properties-common -y
 RUN add-apt-repository ppa:plt/racket -y
 RUN apt-get install -y racket
 RUN apt-get clean
+RUN raco setup --doc-index --force-user-docs
+


### PR DESCRIPTION
In the followup discussion over at https://github.com/racket/racket/issues/2691 @ed-flanagan suggests [this improved solution](https://github.com/racket/racket/issues/2691#issuecomment-812963346) over my earlier suggestion. Users have only to raco pkg add after and that will now work. 