### PR TITLE
Create setup.sh from base-image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,8 @@ grader-image:
 	docker build -f Dockerfile.grader-image -t shriramk/gradescope-racket .
 
 zip:
+	rm -rf setup.sh
+	echo '#!/bin/bash' > setup.sh
+	tail -n +2 Dockerfile.base-image | cut -f 2- -d ' ' >> setup.sh
 	zip -r upload-to-gradescope.zip setup.sh run_autograder grade.rkt lib-grade.rkt
 


### PR DESCRIPTION
Right now the user who needs to add packages and otherwise modify the basic environment needs to remember to change it in two places. If he forgets it can be especially tough to debug, since it seems to work locally. Constructing the setup _from_ the Dockerfile maintains that single point of truth.