### PR TITLE
Add support for (nested) test-suite names in grader

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ There are three files to help you create your own grader:
 If you use the template, be sure to edit only the `UPPER-CASE` parts
 of it.
 
-For now, you can have only one test suite per file/grading run. The
-suite can, of course, have as many tests as you want.
+You can have only one test suite per file/grading run, but test suites can be
+nested so this does not impose much of a limitation.
 
 Once you've created your test suite, you will probably want to test it
 locally first. This requires you to have Docker installed (but not
@@ -96,6 +96,21 @@ of these, from least to most informative:
   (test-equal? "a negative number" (sq -1) 1)
   (test-equal? "-1" (sq -1) 1)
 ```
+
+Test suites can also have names, and be nested. For example:
+```
+(test-suite
+  "Test suite 1"
+  (test-equal? "" (sq -1) 1)
+  (test-suite
+    "Tricky Tests"
+    (test-equal? "-1" (sq -1) 1)))
+```
+
+When names suites have names, the names of test suites and their tests are
+appended hierarchically when reporting test failures and errors to GradeScope.
+In the above example, if the tricky test fails, then the test will report `Test
+suite 1:Tricky Tests:-1` failed.
 
 ## Why `define-var`
 

--- a/grade-two-funs.rkt
+++ b/grade-two-funs.rkt
@@ -7,10 +7,18 @@
 (define-var add-one from "code.rkt")
 (define-var sub-one from "code.rkt")
 
-(define-test-suite tests
-  (test-equal? "+1 0" (add-one 0) 1)
-  (test-equal? "+1 1" (add-one 1) 2)
-  (test-equal? "-1 1" (sub-one 1) 0)
-  (test-equal? "-1 0" (sub-one 0) -1))
+(define tests
+  (test-suite
+   ""
+   (test-suite
+    "add-one test suite"
+    (test-suite
+     "extra nesting for testing"
+     (test-equal? "+1 0" (add-one 0) 1))
+    (test-equal? "+1 1" (add-one 1) 2))
+   (test-suite
+    "sub-one test suite"
+    (test-equal? "-1 1" (sub-one 1) 0)
+    (test-equal? "-1 0" (sub-one 0) -1))))
 
 (generate-results tests)

--- a/lib-grade.rkt
+++ b/lib-grade.rkt
@@ -72,7 +72,7 @@
                 (produce-report/exit
                  `#hasheq((score . 0)
                           (output . ,(string-append "File " bfn " not found: please check your submission"))))))]))]))
-                  
+
 (define (generate-results test-suite)
   (let* ([test-results (fold-test-results cons empty test-suite)]
          [raw-score (* 100

--- a/lib-grade.rkt
+++ b/lib-grade.rkt
@@ -74,9 +74,65 @@
                           (output . ,(string-append "File " bfn " not found: please check your submission"))))))]))]))
 
 (define (generate-results test-suite)
-  (let* ([test-results (fold-test-results cons empty test-suite)]
+  (struct fold-state (successes errors failures names) #:transparent)
+
+  (define init-state (fold-state (list) (list) (list) (list)))
+
+  (define (push-suite-name name state)
+    (struct-copy fold-state state [names (cons name (fold-state-names state))]))
+
+  (define (pop-suite-name name state)
+    (struct-copy fold-state state [names (rest (fold-state-names state))]))
+
+  (define (make-name state result)
+    (define new-name
+      (string-join
+       (filter (lambda (s) (and s (not (equal? s ""))))
+               (append (reverse (fold-state-names state)) (list (test-result-test-case-name result))))
+       ":"))
+    (if (equal? new-name "")
+        #f
+        new-name))
+
+  (define (add-error state result)
+    (struct-copy fold-state
+                 state
+                 [errors (cons (make-name state result)
+                               (fold-state-errors state))]))
+
+  (define (add-failure state result)
+    (struct-copy fold-state
+                 state
+                 [failures (cons (make-name state result)
+                                 (fold-state-failures state))]))
+
+  (define (add-success state result)
+    (struct-copy fold-state
+                 state
+                 [successes (cons (make-name state result)
+                                  (fold-state-successes state))]))
+
+  (define (add-result result state)
+    (cond
+      [(test-failure? result)
+       (add-failure state result)]
+      [(test-error? result)
+       (add-error state result)]
+      [(test-success? result)
+       (add-success state result)]))
+
+  (define (fold-state-total-results state)
+    (+
+     (length (fold-state-successes state))
+     (length (fold-state-errors state))
+     (length (fold-state-failures state))))
+
+  (let* ([test-results (fold-test-results add-result init-state test-suite
+                                          #:fdown push-suite-name
+                                          #:fup pop-suite-name)]
          [raw-score (* 100
-                       (/ (length (filter test-success? test-results)) (length test-results)))]
+                       (/ (length (fold-state-successes test-results))
+                          (fold-state-total-results test-results)))]
          [score-str (number->string (exact->inexact raw-score))])
     (if (= raw-score 100)
         (produce-report/exit
@@ -85,15 +141,23 @@
         (produce-report/exit
          `#hasheq((score . ,score-str)
                   (tests . ,(append
-                             (map (λ (t)
+                             (map (λ (name)
                                     `#hasheq((output
-                                              . ,(string-append "Execution error in test named «"
-                                                                (test-result-test-case-name t)
-                                                                "»"))))
-                                  (filter test-error? test-results))
-                             (map (λ (t)
+                                              . ,(cond
+                                                   [name =>
+                                                    (lambda (test-case-name)
+                                                      (string-append "Execution error in test named «"
+                                                                     test-case-name
+                                                                     "»"))]
+                                                   [else "Execution error in unnamed test"]))))
+                                  (fold-state-errors test-results))
+                             (map (λ (name)
                                     `#hasheq((output
-                                              . ,(string-append "Incorrect answer from test named «"
-                                                                (test-result-test-case-name t)
-                                                                "»"))))
-                                  (filter test-failure? test-results)))))))))
+                                              . ,(cond
+                                                   [name =>
+                                                    (lambda (test-case-name)
+                                                      (string-append "Incorrect answer from test named «"
+                                                                     test-case-name
+                                                                     "»"))]
+                                                   [else "Incorrect answer from unnamed test"]))))
+                                  (fold-state-failures test-results)))))))))

--- a/tests/two-funs/s3/code.rkt
+++ b/tests/two-funs/s3/code.rkt
@@ -1,0 +1,5 @@
+#lang racket
+
+(define (add-one n) (- n 1))
+
+(define (sub-one n) (- n 1))


### PR DESCRIPTION
json output now reports the hierarchy of test-suite names for failing/erroring tests.

This is documented in the README and grade-two-funs and
tests/two-funs/s3/code.rkt provide a grader and mock submission that
demonstrates the reporting.