### PR TITLE
Timeout Individual Test Cases

### DIFF
--- a/lib-grade.rkt
+++ b/lib-grade.rkt
@@ -127,7 +127,7 @@
     (struct-copy fold-state
                  state
                  [timeouts (cons (make-name state result)
-                                  (fold-state-successes state))]))
+                                  (fold-state-timeouts state))]))
 
   (define (add-result result state)
     (cond


### PR DESCRIPTION
Another attempt at #23, except this adds a timeout per test, as well as special reporting so that students can see that their test timed out, as opposed to erroring or failing.

Gradescope docker containers will still die when too many tests time out, as the timeout is only imposed on individual test cases, not the entire test suite tree.

### Usage

Modified `grade-sq.rkt` before running `make grade a=sq s=sq/s1`, although this should work no matter how you get you get these tests to run:

```racket
...
(define (sq-loop x) (sq-loop x))
(define (sq x) (* x x))
(define (sq-error x) (/ x 0))

(define-test-suite sq-tests
  (test-equal? "0" (sq 0) 0)
  (test-equal? "1" (sq 1) 1)
  (test-equal? "-1" (sq -1) 1)
  (test-equal? "2" (sq 2) 4)
  (test-equal? "3" (sq 3) 9)
  (test-equal? "loop" (sq-loop 1) 1)
  (test-equal? "error" (sq-error 1) 1)
  )
(parameterize ([test-case-timeout 0.5])
  (generate-results sq-tests))
```


```bash
{
  "score": "71.42857142857143",
  "tests":[{"output":"Execution timed out in test named «sq-tests:loop»"},
                {"output":"Execution error in test named «sq-tests:error»"}]
}
```