### PR TITLE
Updated ubuntu image; added note for Apple Silicon users, xvfb dependency for GUI

### DIFF
--- a/Dockerfile.base-image
+++ b/Dockerfile.base-image
@@ -1,9 +1,8 @@
-FROM gradescope/auto-builds:ubuntu-18.04
+FROM gradescope/auto-builds:ubuntu-22.04
 
 RUN apt-get update -y
 RUN apt-get install software-properties-common -y
 RUN add-apt-repository ppa:plt/racket -y
-RUN apt-get install -y racket
+RUN apt-get install -y racket xvfb
 RUN apt-get clean
 RUN raco setup --doc-index --force-user-docs
-

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,9 @@ gradescope-$(a).zip: grade.rkt
 	tail -n +2 Dockerfile.base-image | cut -f 2- -d ' ' >> setup.sh
 	zip -r upload-to-gradescope.zip setup.sh run_autograder grade.rkt lib-grade.rkt
 
+clean:
+	- rm -rf autograder
+	- rm -f setup.sh
+	- rm -f gradescope-$(a).zip
+	- rm -f grade.rkt
+	- rm -f upload-to-gradescope.zip

--- a/README.md
+++ b/README.md
@@ -220,14 +220,28 @@ number of tests. That's it. Someday I may look into adding weights for
 tests, etc., but I'm really not excited about any of it. Either way,
 please give your students instructions on how to interpret the numbers.
 
+## Settings for newer Apple Macs and other Alternative Platforms
+
+On [Apple Silicon][how-to-tell] or other arm64 based architectures,
+these Docker images will not build correctly, because the
+`gradescope-base` images expect an amd64 platform. To work around
+this, users will need to either
+
+- Set the `DOCKER_DEFAULT_PLATFORM` environment variable (permanently
+  by adding `export DOCKER_DEFAULT_PLATFORM=linux/amd64` to your
+  `bashrc`) or
+- If you regularly use Docker for other purposes, you could add to the
+  flag `--platform=linux/amd64` to the `docker build` and `docker run`
+  commands in the `Makefile`.
+
 ## Open Issues
 
 See <https://github.com/shriram/gradescope-racket/issues/>.
 
 ## Is This Current?
 
-This code has been tested with Gradescope in late May 23, 2020, using
-Racket 7.7. Since Gradescope's APIs are in some flux, you may
+This code has been tested with Gradescope in late August 30, 2024, using
+Racket 8.14. Since Gradescope's APIs are in some flux, you may
 encounter errors with newer versions; contact me and I'll try to
 help. In addition, Gradescope intends to make it easier to deploy
 autograders using Docker; when that happens, it would be nice to
@@ -251,3 +265,5 @@ Gradescope's "specs" are currently at:
 
 Thanks to Matthew Flatt, Alex Harsanyi, David Storrs, Alexis King,
 Matthias Felleisen, Joe Politz, and James Tompkin.
+
+[how-to-tell]: https://support.apple.com/en-us/116943

--- a/lib-grade.rkt
+++ b/lib-grade.rkt
@@ -196,9 +196,11 @@
                                           #:run (if (test-case-timeout) run-test-case/timeout run-test-case)
                                           #:fdown push-suite-name
                                           #:fup pop-suite-name)]
-         [raw-score (* 100
-                       (/ (length (fold-state-successes test-results))
-                          (fold-state-total-results test-results)))]
+         [raw-score (if (zero? (fold-state-total-results test-results))
+                        100
+                        (* 100
+                           (/ (length (fold-state-successes test-results))
+                              (fold-state-total-results test-results))))]
          [score-str (number->string (exact->inexact raw-score))])
     (if (= raw-score 100)
         `#hasheq((score . "100")


### PR DESCRIPTION
# Dockerfile.base-image
- Switching to the 22.04 LTS base image
- adding `xvfb` for GUI programs

# Makefile
- added a `clean` target 

# lib-grade.rkt 
- caught a possible div-by-zero exception in tests.

